### PR TITLE
Fix wrong `:type`

### DIFF
--- a/dap-php.el
+++ b/dap-php.el
@@ -40,12 +40,12 @@
   (-> conf
       (dap--put-if-absent :dap-server-path dap-php-debug-program)
       (dap--put-if-absent :type "node")
-      (dap--put-if-absent :cwd projectile-project-root)
+      (dap--put-if-absent :cwd (lsp-find-session-folder (lsp-session) (buffer-file-name)))
       (dap--put-if-absent :name "Php Debug")))
 
 (dap-register-debug-provider "php" 'dap-php--populate-start-file-args)
 (dap-register-debug-template "Php Run Configuration"
-                             (list :type "node"
+                             (list :type "php"
                                    :cwd nil
                                    :request "launch"
                                    :name "Php Debug"


### PR DESCRIPTION
`:type` must be `php` not `node`

This is my working configuration.

`:args` is open to debate, I don't really know how to write this so that it's passed correctly on to the node process -- if this is fixed the port should probably be changed to `9000`